### PR TITLE
fix participating stations parsing

### DIFF
--- a/src/gmn_python_api/meteor_trajectory_reader.py
+++ b/src/gmn_python_api/meteor_trajectory_reader.py
@@ -121,6 +121,6 @@ def _set_data_types(dataframe: pd.DataFrame) -> None:
     ].astype("string")
     dataframe["Participating (stations)"] = dataframe[
         "Participating (stations)"
-    ].apply(lambda x: x[1:-1].split(","))
+    ].apply(lambda x: x.split(","))
 
     dataframe.set_index("Unique trajectory (identifier)", inplace=True)


### PR DESCRIPTION
### Summary of work

For a given meteor, participating station parsing outputs:

['SL005', 'USL00A', 'USL00J', 'USL00Y', 'USL012', 'USL01A', 'USL01']

instead of:

['USL005', 'USL00A', 'USL00J', 'USL00Y', 'USL012', 'USL01A', 'USL01E']

### How to test your work


```
import gmn_python_api

daily_data = gmn_python_api.data_directory.get_daily_file_content_by_date('2022-10-01')
daily_data_df = gmn_python_api.meteor_trajectory_reader.read_csv(
        daily_data, output_camel_case=True)
stations = daily_data_df["participating_stations"]
print(stations['20221001122102_2DrBF'])
```


